### PR TITLE
Devcontainer added

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,11 @@
+# Devcontainer readme
+This directory allows you to develop your adapter in a dedicated Docker container. To get started and for requirements, please read the getting started section at https://code.visualstudio.com/docs/remote/containers#_getting-started
+
+Once you're done with that, VSCode will prompt you to reopen the adapter directory in a container. This takes a while. Afterward, you can access the admin UI by the forwarded port **Ports** panel in VS Code. 
+
+1. Open the **Ports** panel in VS Code (look for the "Ports" tab in the bottom panel or use the Command Palette with `Ctrl+Shift+P` and search for "Ports: Focus on Ports View").
+2. Locate the forwarded port for the admin UI (usually dynamically assigned).
+3. Click the link in the **Ports** panel to open the admin UI in your browser.
+
+By default, the admin UI is available at `http://localhost:<forwarded-port>`.
+To change the port, edit `devcontainer.json` to have a different `forwardPorts` configuration for `nginx`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.101.1/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+    "name": "ioBroker.training",
+
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+    "dockerComposeFile": [ "docker-compose.yml" ],
+
+ 	// Forwarding the nginx port to access ioBroker Admin interface
+    "forwardPorts": ["nginx:80"],
+
+    // Name of the forwarded port
+    "portsAttributes": {
+        "nginx:80": {
+            "label": "ioBroker Admin UI"
+        }
+    },
+
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "iobroker",
+
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/workspace",
+
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {},
+
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": ["dbaeumer.vscode-eslint"]
+        }
+    },
+
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+
+    // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+
+    // Prepare the devcontainer according to the actual adapter
+    "postCreateCommand": "sh .devcontainer/scripts/postcreate.sh",
+    "postStartCommand": "sh .devcontainer/scripts/poststart.sh",
+
+    // Connect as non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "iobroker"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+    iobroker:
+        build: ./iobroker
+        container_name: iobroker-training
+        hostname: iobroker-training
+        # This port is only internal, so we can work on this while another instance of ioBroker is running on the host
+        expose:
+            - 8081
+        volumes:
+            - ..:/workspace:cached
+        environment:
+            # using non-default ports to not interfere with integration tests
+            - IOB_OBJECTSDB_TYPE=jsonl
+            - IOB_OBJECTSDB_HOST=127.0.0.1
+            - IOB_OBJECTSDB_PORT=29001
+            - IOB_STATESDB_TYPE=jsonl
+            - IOB_STATESDB_HOST=127.0.0.1
+            - IOB_STATESDB_PORT=29000
+            - LANG=en_US.UTF-8
+            - LANGUAGE=en_US:en
+            - LC_ALL=en_US.UTF-8
+            - TZ=Europe/Berlin
+            - SETGID=1000
+
+    # Reverse proxy to load up-to-date admin sources from the repo
+    nginx:
+        image: nginx:latest
+        depends_on:
+            - iobroker
+        links:
+            - iobroker
+        container_name: nginx-training
+        volumes:
+            - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+            - ..:/workspace:cached
+        ports:
+            # Port will be forwarded in the devcontainer
+            - 80

--- a/.devcontainer/iobroker/Dockerfile
+++ b/.devcontainer/iobroker/Dockerfile
@@ -1,0 +1,25 @@
+FROM iobroker/iobroker:latest
+RUN ln -s /opt/iobroker/node_modules/ /node_modules
+
+# add ssh client to be able to work with git
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install openssh-client
+
+COPY node-wrapper.sh /usr/bin/node-wrapper.sh
+RUN chmod +x /usr/bin/node-wrapper.sh \
+    && NODE_BIN="$(command -v node)" \
+    # Move the original node binary to .real
+    && mv "$NODE_BIN" "${NODE_BIN}.real" \
+    # Move the wrapper in place
+    && mv /usr/bin/node-wrapper.sh "$NODE_BIN"
+
+# Support sudo for non-root user
+ARG USERNAME=iobroker
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+COPY boot.sh /opt/iobroker/boot.sh
+RUN chmod +x /opt/iobroker/boot.sh \
+    && mkdir -p /opt/iobroker/log
+
+ENTRYPOINT ["/bin/bash", "-c", "/opt/iobroker/boot.sh"]

--- a/.devcontainer/iobroker/boot.sh
+++ b/.devcontainer/iobroker/boot.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Define log file location
+LOG_FILE=/opt/iobroker/log/boot.log
+mkdir -p /opt/iobroker/log
+
+# Start logging to the file (standard output and error)
+exec > >(tee "$LOG_FILE") 2>&1
+
+/opt/scripts/iobroker_startup.sh

--- a/.devcontainer/iobroker/node-wrapper.sh
+++ b/.devcontainer/iobroker/node-wrapper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Wrap the Node.js binary to handle NODE_OPTIONS as command-line arguments.
+# This workaround addresses https://github.com/nodejs/node/issues/37588, where
+# NODE_OPTIONS is not respected when running Node.js with capabilities as a non-root user.
+# The wrapper script reads the NODE_OPTIONS environment variable and converts it into
+# standard command-line arguments. For example:
+# NODE_OPTIONS=--inspect node main.js
+# becomes:
+# node.real --inspect main.js
+# This ensures debugging, and other features relying on NODE_OPTIONS work properly
+# for non-root users, such as in VS Code Remote Containers.
+
+NODE_ARGS=()
+
+if [[ -n "$NODE_OPTIONS" ]]; then
+    eval "read -r -a NODE_ARGS <<< \"$NODE_OPTIONS\""
+    unset NODE_OPTIONS
+fi
+
+REAL_NODE="$(command -v node).real"
+exec "$REAL_NODE" "${NODE_ARGS[@]}" "$@"

--- a/.devcontainer/nginx/nginx.conf
+++ b/.devcontainer/nginx/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes 1;
+events { worker_connections 1024; }
+
+http {
+  sendfile           on;
+  keepalive_timeout  65;
+
+  server {
+    listen 80;
+
+    location / {
+      error_page 418 = @websocket;      
+      proxy_redirect off;
+      proxy_pass     http://iobroker:8081;
+      if ( $args ~ "sid=" ) { return 418; }      
+    }
+
+    location @websocket {
+      proxy_pass         http://iobroker:8081;
+      proxy_http_version 1.1;
+      proxy_set_header   Upgrade $http_upgrade;
+      proxy_set_header   Connection "Upgrade";
+      proxy_read_timeout 86400;
+      proxy_send_timeout 86400;
+    }
+
+    location /adapter/training/ {
+      alias /workspace/admin/;
+    }
+
+  }
+}

--- a/.devcontainer/scripts/postcreate.sh
+++ b/.devcontainer/scripts/postcreate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# Wait for ioBroker to become ready
+sh .devcontainer/scripts/wait_for_iobroker.sh
+
+echo "➡️  Install dependencies"
+npm install
+
+echo "➡️  Packaging adapter"
+NPM_PACK=$(npm pack)
+
+echo "➡️  Delete discovery adapter"
+iob del discovery
+
+echo "➡️  Disable error reporting"
+iob plugin disable sentry
+
+echo "➡️  Disable sending diagnostics"
+iob object set system.config common.diag=false
+
+echo "➡️  Set the license as confirmed"
+iob object set system.config common.licenseConfirmed=true
+
+echo "➡️  Install the adapter"
+iob url "$(pwd)/$NPM_PACK" --debug
+
+ADAPTER_NAME=$(jq -r '.name | split(".")[1]' package.json)
+echo "➡️  Create a $ADAPTER_NAME instance"
+iob add $ADAPTER_NAME
+
+echo "➡️  Stop $ADAPTER_NAME instance"
+iob stop $ADAPTER_NAME
+
+echo "➡️  Delete the adapter package"
+rm "$NPM_PACK"
+
+touch /tmp/.postcreate_done

--- a/.devcontainer/scripts/poststart.sh
+++ b/.devcontainer/scripts/poststart.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# execute poststart only if container was created right before
+if [ -e /tmp/.postcreate_done ]; then
+    rm  /tmp/.postcreate_done
+else
+    # Wait for ioBroker to become ready
+    sh .devcontainer/scripts/wait_for_iobroker.sh
+fi

--- a/.devcontainer/scripts/wait_for_iobroker.sh
+++ b/.devcontainer/scripts/wait_for_iobroker.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# Start tailing the iobroker boot log and kill it when the script exits
+tail -f -n 100 /opt/iobroker/log/boot.log &
+TAIL_PID_BOOT=$!
+
+# Ensure the tail process is killed when the script exits
+trap "kill $TAIL_PID_BOOT" EXIT
+
+# wait for ioBroker to become ready
+echo "⏳ Waiting for ioBroker to become ready..."
+
+ATTEMPTS=20
+SLEEP=0.5
+i=1
+
+while [ $i -le $ATTEMPTS ]; do
+    if iob status > /dev/null 2>&1; then
+        echo "✅ ioBroker is ready."
+        break
+    else
+        echo "⌛ Attempt $i/$ATTEMPTS: Waiting for ioBroker..."
+        sleep $SLEEP
+        i=$((i + 1))
+    fi
+done
+
+if ! iob status > /dev/null 2>&1; then
+    echo "❌ Timeout: ioBroker did not become ready in time"
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*/
 !.vscode/
 !.github/
+!.devcontainer/
 
 *.code-workspace
 node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,22 @@
             "console": "internalConsole",
             "outputCapture": "std",
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "**/node_modules/**"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "(DC) Launch ioBroker Adapter",
+            "skipFiles": ["<node_internals>/**"],
+            "args": ["--debug", "0", "--logs"],
+            "program": "${workspaceFolder}/main.js",
+            "console": "integratedTerminal"
+        },
+        {
+            "type": "node-terminal",
+            "name": "Update Adapter",
+            "request": "launch",
+            "command": "NPM_PACK=$(npm pack) && iob url $(pwd)/$NPM_PACK --debug && rm $NPM_PACK",
+            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,7 @@
             "name": "(DC) Launch ioBroker Adapter",
             "skipFiles": ["<node_internals>/**"],
             "args": ["--debug", "0", "--logs"],
+            "stopOnEntry": true,
             "program": "${workspaceFolder}/main.js",
             "console": "integratedTerminal"
         },


### PR DESCRIPTION
For remote debugging do the following:

1) Call `code --folder-uri vscode-remote://ssh-remote+<user@ssh-host>/<remote-path-to-ioBroker.training>` or connect to remote host via already opened vscode.
2) Wait for "Reopen in Dev Container" Popup
3) Click on "Connecting to Dev Container" to see the logs
3) Wait until setup is ready (only needed once per container creation, subsequent startups are faster!)
4) Run launch config "(DC) Launch ioBroker Adapter"

Debugger should stop at entry